### PR TITLE
potential fix for the slippage bug

### DIFF
--- a/contracts/Inception/vaults/InceptionVault.sol
+++ b/contracts/Inception/vaults/InceptionVault.sol
@@ -108,7 +108,7 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
         totalAmountToWithdraw += amount;
         Withdrawal storage request = _claimerWithdrawals[receiver];
         request.amount += _getAssetReceivedAmount(amount);
-        request.iShares = iShares;
+        request.iShares += iShares;
         request.receiver = receiver;
         request.epoch = epoch;
 

--- a/contracts/Inception/vaults/InceptionVault.sol
+++ b/contracts/Inception/vaults/InceptionVault.sol
@@ -21,6 +21,7 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
         uint256 epoch;
         address receiver;
         uint256 amount;
+        uint256 iShares;
     }
 
     mapping(address => Withdrawal) private _claimerWithdrawals;
@@ -107,6 +108,7 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
         totalAmountToWithdraw += amount;
         Withdrawal storage request = _claimerWithdrawals[receiver];
         request.amount += _getAssetReceivedAmount(amount);
+        request.iShares = iShares;
         request.receiver = receiver;
         request.epoch = epoch;
 
@@ -124,6 +126,13 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
         );
         Withdrawal storage request = _claimerWithdrawals[receiver];
         uint256 amount = request.amount;
+        /// @notice Ensure the ratio has decreased since the user's withdrawal
+        uint256 currentAmount = Convert.multiplyAndDivideFloor(
+            request.iShares,
+            1e18,
+            ratio()
+        );
+        if (currentAmount < amount) amount = currentAmount;
         totalAmountToWithdraw -= amount;
 
         delete _claimerWithdrawals[receiver];


### PR DESCRIPTION

Your pull request description is detailed and informative. Here's a refined version for enhanced clarity and professionalism:

**Pull Request: Potential Fix for the Slippage Bug**

In this pull request, I propose a potential solution for the identified issue: "**Asset value slippage may cause inconsistent bookkeeping" (Medium)**. The key modifications include:

1. Update to _Withdrawal{}_ structure: Extended the structure with a new field, _iShares_, which tracks the **iShares burned from a user in InceptionToken.**
2. Additional check in _redeem_() function: Implemented the following condition to safeguard against discrepancies:

`if (currentAmount < amount) amount = currentAmount;`

where currentAmount is calculated as:

```
uint256 currentAmount = Convert.multiplyAndDivideFloor(
    request.iShares,
    1e18,
    ratio()
);
```

These changes aim to ensure that the ratio either **decreases or remains the same** following a user's withdrawal, thus addressing the slippage concern and enhancing overall consistency in bookkeeping