### PR TITLE
new contract: InceptionRateProvider

### DIFF
--- a/contracts/InceptionRateProvider/InceptionRateProvider.sol
+++ b/contracts/InceptionRateProvider/InceptionRateProvider.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.14;
+
+import "../interfaces/IRateProvider.sol";
+
+import "../interfaces/IInceptionVault.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
+
+/// @author The InceptionLRT team
+/// @title The InceptionRateProvider contract
+/// @notice Inheritable standard rate provider interface.
+abstract contract InceptionRateProvider is IRateProvider {
+    using SafeMathUpgradeable for uint256;
+
+    IInceptionVault public inceptionVault;
+
+    constructor(address vaultAddress) {
+        inceptionVault = IInceptionVault(vaultAddress);
+    }
+
+    function getRate() external view override returns (uint256) {
+        return safeFloorMultiplyAndDivide(1e18, 1e18, inceptionVault.ratio());
+    }
+
+    function safeFloorMultiplyAndDivide(
+        uint256 a,
+        uint256 b,
+        uint256 c
+    ) internal pure returns (uint256) {
+        uint256 remainder = a.mod(c);
+        uint256 result = a.div(c);
+        bool safe;
+        (safe, result) = result.tryMul(b);
+        if (!safe) {
+            return
+                0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+        }
+        (safe, result) = result.tryAdd(remainder.mul(b).div(c));
+        if (!safe) {
+            return
+                0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+        }
+        return result;
+    }
+}

--- a/contracts/InceptionRateProvider/InceptionRateProvider.sol
+++ b/contracts/InceptionRateProvider/InceptionRateProvider.sol
@@ -15,7 +15,7 @@ abstract contract InceptionRateProvider is IRateProvider {
 
     IInceptionVault public inceptionVault;
 
-    constructor(address vaultAddress) {
+    constructor(address vaultAddress) payable {
         inceptionVault = IInceptionVault(vaultAddress);
     }
 

--- a/contracts/InceptionRateProvider/InstETHRateProvider.sol
+++ b/contracts/InceptionRateProvider/InstETHRateProvider.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.14;
+
+import "./InceptionRateProvider.sol";
+
+/// @author The InceptionLRT team
+/// @title The InstETHRateProvider contract
+/// @notice The InceptionRateProvider is used to build a rate provider for instETH LRT.
+contract InstETHRateProvider is InceptionRateProvider {
+    // --- Init ---
+    constructor(address vaultAddress) InceptionRateProvider(vaultAddress) {}
+
+    function instETH() external view returns (address) {
+        return address(inceptionVault.inceptionToken());
+    }
+}

--- a/contracts/InceptionRateProvider/InstETHRateProvider.sol
+++ b/contracts/InceptionRateProvider/InstETHRateProvider.sol
@@ -9,7 +9,9 @@ import "./InceptionRateProvider.sol";
 /// @notice The InceptionRateProvider is used to build a rate provider for instETH LRT.
 contract InstETHRateProvider is InceptionRateProvider {
     // --- Init ---
-    constructor(address vaultAddress) InceptionRateProvider(vaultAddress) {}
+    constructor(
+        address vaultAddress
+    ) payable InceptionRateProvider(vaultAddress) {}
 
     function instETH() external view returns (address) {
         return address(inceptionVault.inceptionToken());

--- a/contracts/interfaces/IInceptionVault.sol
+++ b/contracts/interfaces/IInceptionVault.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/interfaces/IERC4626Upgradeable.sol";
+import "./IInceptionToken.sol";
 
 interface IInceptionVault {
     /*///////////////////
@@ -46,4 +47,8 @@ interface IInceptionVault {
     event NameChanged(string prevValue, string newValue);
 
     event ReferralCode(bytes32 indexed code);
+
+    function inceptionToken() external view returns (IInceptionToken);
+
+    function ratio() external view returns (uint256);
 }

--- a/contracts/interfaces/IRateProvider.sol
+++ b/contracts/interfaces/IRateProvider.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.14;
+
+/**
+ *  Balancer rate interface.
+ */
+interface IRateProvider {
+    function getRate() external view returns (uint256);
+}

--- a/scripts/migration/mainnet/deploy-st-rate.js
+++ b/scripts/migration/mainnet/deploy-st-rate.js
@@ -1,0 +1,22 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  console.log(`Deploying InstETHRateProvider with the account: ${deployer.address}`);
+  const initBalance = await deployer.provider.getBalance(deployer.address);
+  console.log("Account balance:", initBalance.toString());
+
+  const InstETHRateProviderFactory = await hre.ethers.getContractFactory("InstETHRateProvider");
+  const rateProvider = await InstETHRateProviderFactory.deploy();
+  await rateProvider.waitForDeployment();
+
+  console.log("RateProvider address: ", (await rateProvider.getAddress()).toString());
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/migration/mainnet/deploy-st-rate.js
+++ b/scripts/migration/mainnet/deploy-st-rate.js
@@ -8,7 +8,7 @@ async function main() {
   console.log("Account balance:", initBalance.toString());
 
   const InstETHRateProviderFactory = await hre.ethers.getContractFactory("InstETHRateProvider");
-  const rateProvider = await InstETHRateProviderFactory.deploy();
+  const rateProvider = await InstETHRateProviderFactory.deploy("0x814CC6B8fd2555845541FB843f37418b05977d8d");
   await rateProvider.waitForDeployment();
 
   console.log("RateProvider address: ", (await rateProvider.getAddress()).toString());


### PR DESCRIPTION
This pull request introduces the following crucial changes to the _InceptionLRT Protocol_:

- Introduction of a new contract, `InceptionRateProvider`. Specifically, it aims to facilitate integration with the _InceptionLRT_ Protocol smoothly, especially for the _Balancer team_.
- In this release, we deployed the first instance of `InceptionRateProvider`, particularly for `instETH` LRT.
- Added a corresponding migration