### PR TITLE
Delegation from the vault

### DIFF
--- a/contracts/Inception/eigenlayer-handler/EigenLayerHandler.sol
+++ b/contracts/Inception/eigenlayer-handler/EigenLayerHandler.sol
@@ -62,6 +62,11 @@ contract EigenLayerHandler is InceptionAssetsHandler, IEigenLayerHandler {
         strategy = _assetStrategy;
 
         __InceptionAssetsHandler_init(_assetStrategy.underlyingToken());
+        // approve spending by strategyManager
+        require(
+            _asset.approve(address(strategyManager), type(uint256).max),
+            "EigenLayerHandler: approve failed"
+        );
     }
 
     /*//////////////////////////////
@@ -94,12 +99,18 @@ contract EigenLayerHandler is InceptionAssetsHandler, IEigenLayerHandler {
     ) internal {
         _asset.approve(restaker, amount);
         IInceptionRestaker(restaker).depositAssetIntoStrategy(amount);
+
+        emit DepositedToEL(restaker, amount);
     }
 
     function depositAssetIntoStrategyFromVault(
         uint256 amount
     ) external nonReentrant onlyOperator {
+        _beforeDepositAssetIntoStrategy(amount);
+
         strategyManager.depositIntoStrategy(strategy, _asset, amount);
+
+        emit DepositedToEL(address(this), amount);
     }
 
     /// @dev deposits asset to the corresponding strategy
@@ -178,6 +189,54 @@ contract EigenLayerHandler is InceptionAssetsHandler, IEigenLayerHandler {
         IInceptionRestaker(stakerAddress).withdrawFromEL(shares);
     }
 
+    /// @dev performs creating a withdrawal request from EigenLayer
+    /// @dev requires a specific amount to withdraw
+    function undelegateVault(
+        uint256 amount
+    ) external whenNotPaused nonReentrant onlyOperator {
+        address staker = address(this);
+        uint256 nonce = delegationManager.cumulativeWithdrawalsQueued(staker);
+        uint256 totalAssetSharesInEL = strategyManager.stakerStrategyShares(
+            staker,
+            strategy
+        );
+        uint256 shares = strategy.underlyingToSharesView(amount);
+        // we need to withdraw the remaining dust from EigenLayer
+        if (totalAssetSharesInEL < shares + 5) {
+            shares = totalAssetSharesInEL;
+        }
+        amount = strategy.sharesToUnderlyingView(shares);
+
+        uint256[] memory sharesToWithdraw = new uint256[](1);
+        IStrategy[] memory strategies = new IStrategy[](1);
+
+        strategies[0] = strategy;
+        sharesToWithdraw[0] = shares;
+        IDelegationManager.QueuedWithdrawalParams[]
+            memory withdrawals = new IDelegationManager.QueuedWithdrawalParams[](
+                1
+            );
+
+        withdrawals[0] = IDelegationManager.QueuedWithdrawalParams({
+            strategies: strategies,
+            shares: sharesToWithdraw,
+            withdrawer: address(this)
+        });
+
+        _pendingWithdrawalAmount += amount;
+
+        delegationManager.queueWithdrawals(withdrawals);
+
+        emit StartWithdrawal(
+            staker,
+            strategy,
+            shares,
+            uint32(block.number),
+            delegationManager.delegatedTo(staker),
+            nonce
+        );
+    }
+
     /// @dev claims completed withdrawals from EigenLayer, if they exist
     function claimCompletedWithdrawals(
         address restaker,
@@ -197,12 +256,22 @@ contract EigenLayerHandler is InceptionAssetsHandler, IEigenLayerHandler {
             }
         }
 
-        uint256 withdrawnAmount = IInceptionRestaker(restaker).claimWithdrawals(
-            withdrawals,
-            tokens,
-            middlewareTimesIndexes,
-            receiveAsTokens
-        );
+        uint256 withdrawnAmount;
+        if (restaker == address(this)) {
+            withdrawnAmount = _claimCompletedWithdrawalsForVault(
+                withdrawals,
+                tokens,
+                middlewareTimesIndexes,
+                receiveAsTokens
+            );
+        } else {
+            withdrawnAmount = IInceptionRestaker(restaker).claimWithdrawals(
+                withdrawals,
+                tokens,
+                middlewareTimesIndexes,
+                receiveAsTokens
+            );
+        }
 
         emit WithdrawalClaimed(withdrawnAmount);
 
@@ -215,6 +284,28 @@ contract EigenLayerHandler is InceptionAssetsHandler, IEigenLayerHandler {
         }
 
         _updateEpoch();
+    }
+
+    function _claimCompletedWithdrawalsForVault(
+        IDelegationManager.Withdrawal[] memory withdrawals,
+        IERC20[][] memory tokens,
+        uint256[] memory middlewareTimesIndexes,
+        bool[] memory receiveAsTokens
+    ) internal returns (uint256) {
+        uint256 balanceBefore = _asset.balanceOf(address(this));
+
+        delegationManager.completeQueuedWithdrawals(
+            withdrawals,
+            tokens,
+            middlewareTimesIndexes,
+            receiveAsTokens
+        );
+
+        // send tokens to the vault
+        uint256 withdrawnAmount = _asset.balanceOf(address(this)) -
+            balanceBefore;
+
+        return withdrawnAmount;
     }
 
     function updateEpoch() external whenNotPaused onlyOperator {

--- a/contracts/Inception/eigenlayer-handler/EigenLayerHandler.sol
+++ b/contracts/Inception/eigenlayer-handler/EigenLayerHandler.sol
@@ -96,6 +96,17 @@ contract EigenLayerHandler is InceptionAssetsHandler, IEigenLayerHandler {
         IInceptionRestaker(restaker).depositAssetIntoStrategy(amount);
     }
 
+    function depositAssetIntoStrategyFromVault(
+        uint256 amount
+    ) external nonReentrant onlyOperator {
+        strategyManager.depositIntoStrategy(strategy, _asset, amount);
+    }
+
+    /// @dev deposits asset to the corresponding strategy
+    function _depositAssetIntoStrategyFromVault(uint256 amount) internal {
+        strategyManager.depositIntoStrategy(strategy, _asset, amount);
+    }
+
     /// @dev delegates assets held in the strategy to the EL operator.
     function _delegateToOperator(
         address restaker,
@@ -107,6 +118,18 @@ contract EigenLayerHandler is InceptionAssetsHandler, IEigenLayerHandler {
             elOperator,
             approverSalt,
             approverSignatureAndExpiry
+        );
+    }
+
+    function _delegateToOperatorFromVault(
+        address elOperator,
+        bytes32 approverSalt,
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry
+    ) internal {
+        delegationManager.delegateTo(
+            elOperator,
+            approverSignatureAndExpiry,
+            approverSalt
         );
     }
 

--- a/contracts/Inception/vaults/InceptionVault.sol
+++ b/contracts/Inception/vaults/InceptionVault.sol
@@ -150,6 +150,29 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
         emit DelegatedTo(restaker, elOperator, amount);
     }
 
+    function delegateToOperatorFromVault(
+        uint256 amount,
+        address elOperator,
+        bytes32 approverSalt,
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry
+    ) external nonReentrant whenNotPaused onlyOperator {
+        if (elOperator == address(0)) {
+            revert NullParams();
+        }
+        if (delegationManager.delegatedTo(address(this)) == address(0))
+            revert AlreadyDelegated();
+
+        _beforeDepositAssetIntoStrategy(amount);
+
+        _delegateToOperatorFromVault(
+            elOperator,
+            approverSalt,
+            approverSignatureAndExpiry
+        );
+
+        emit DelegatedTo(address(this), elOperator, amount);
+    }
+
     /*///////////////////////////////////////
     ///////// Withdrawal functions /////////
     /////////////////////////////////////*/
@@ -342,7 +365,7 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
                 ++i;
             }
         }
-        return total;
+        return total + strategy.userUnderlyingView(address(this));
     }
 
     function getDelegatedTo(address elOperator) public view returns (uint256) {

--- a/contracts/Inception/vaults/InceptionVault.sol
+++ b/contracts/Inception/vaults/InceptionVault.sol
@@ -147,11 +147,10 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
                 approverSignatureAndExpiry
             );
 
-        emit DelegatedTo(restaker, elOperator, amount);
+        emit DelegatedTo(restaker, elOperator);
     }
 
     function delegateToOperatorFromVault(
-        uint256 amount,
         address elOperator,
         bytes32 approverSalt,
         IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry
@@ -159,10 +158,8 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
         if (elOperator == address(0)) {
             revert NullParams();
         }
-        if (delegationManager.delegatedTo(address(this)) == address(0))
+        if (delegationManager.delegatedTo(address(this)) != address(0))
             revert AlreadyDelegated();
-
-        _beforeDepositAssetIntoStrategy(amount);
 
         _delegateToOperatorFromVault(
             elOperator,
@@ -170,7 +167,7 @@ contract InceptionVault is IInceptionVault, EigenLayerHandler {
             approverSignatureAndExpiry
         );
 
-        emit DelegatedTo(address(this), elOperator, amount);
+        emit DelegatedTo(address(this), elOperator);
     }
 
     /*///////////////////////////////////////

--- a/contracts/interfaces/IEigenLayerHandler.sol
+++ b/contracts/interfaces/IEigenLayerHandler.sol
@@ -26,8 +26,7 @@ interface IEigenLayerHandler {
 
     event DelegatedTo(
         address indexed stakerAddress,
-        address indexed operatorAddress,
-        uint256 amount
+        address indexed operatorAddress
     );
 
     event Withdrawn(address asset, uint256 shares, uint256 ethAmount);

--- a/contracts/interfaces/IInceptionVaultErrors.sol
+++ b/contracts/interfaces/IInceptionVaultErrors.sol
@@ -22,6 +22,8 @@ interface IInceptionVaultErrors {
 
     error EigenLayerOperatorAlreadyExists();
 
+    error AlreadyDelegated();
+
     /// TVL errors
 
     error ExceedsMaxPerDeposit(uint256 max, uint256 amount);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -14,7 +14,7 @@ module.exports = {
       forking: {
         url: `${process.env.RPC_URL_HOLESKY}`,
         blockNumber: 1232177,
-      }
+      },
     },
     hardhat_mainnet: {
       forking: {
@@ -35,7 +35,7 @@ module.exports = {
   solidity: {
     compilers: [
       {
-        version: "0.8.17",
+        version: "0.8.20",
         settings: {
           optimizer: {
             enabled: true,

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -13,7 +13,7 @@ const withdrawDataFromTx = async (tx, operatorAddress, restaker) => {
     console.log(receipt.logs);
   }
 
-  const WithdrawalQueuedEvent = receipt.logs[0].args;
+  const WithdrawalQueuedEvent = receipt.logs?.find((e) => e.eventName === "StartWithdrawal").args;
   return [
     WithdrawalQueuedEvent["stakerAddress"],
     operatorAddress,


### PR DESCRIPTION
The PR introduces some crucial features for the InceptionLRT protocol, making it more flexible and robust. Specifically, a new method for delegating assets in EigenLayer was added to the second version of Inception, allowing **direct delegation from the vault**. This is essential to provide the maximum APR for our customers in a bullish crypto market. The following functions will help us accomplish _this goal_:

1. `depositAssetIntoStrategyFromVault()` places the assets into the corresponding EL strategy, with the vault acting as the _depositor_.
2. `delegateToOperatorFromVault()` delegates assets in such a way that the vault is considered the _depositor_.
3. `undelegateVault()` undelegates assets from EigenLayer, with the vault acting as the _depositor_.
4. Additionally, the `claimCompletedWithdrawals()` function was adjusted to accommodate the above changes.