### PR TITLE
SymbioticVault: Emergency withdrawal deprecated; distinct min amounts

### DIFF
--- a/projects/vaults/contracts/interfaces/symbiotic-vault/IIMellowRestaker.sol
+++ b/projects/vaults/contracts/interfaces/symbiotic-vault/IIMellowRestaker.sol
@@ -83,10 +83,10 @@ interface IIMellowRestaker {
     ) external returns (uint256);
 
     
-    function withdrawEmergencyMellow(
-        address _mellowVault,
-        uint256 _deadline
-    ) external returns (uint256);
+    // function withdrawEmergencyMellow(
+    //     address _mellowVault,
+    //     uint256 _deadline
+    // ) external returns (uint256);
 
     function claimMellowWithdrawalCallback() external returns (uint256);
 

--- a/projects/vaults/contracts/interfaces/symbiotic-vault/IInceptionVault_S.sol
+++ b/projects/vaults/contracts/interfaces/symbiotic-vault/IInceptionVault_S.sol
@@ -42,7 +42,12 @@ interface IInceptionVault_S {
 
     event OperatorChanged(address prevValue, address newValue);
 
-    event MinAmountChanged(uint256 prevValue, uint256 newValue);
+    event WithdrawMinAmountChanged(uint256 prevValue, uint256 newValue);
+
+    event DepositMinAmountChanged(uint256 prevValue, uint256 newValue);
+
+    event FlashMinAmountChanged(uint256 prevValue, uint256 newValue);
+
 
     event RatioFeedChanged(address prevValue, address newValue);
 

--- a/projects/vaults/contracts/mellow-handler/MellowHandler.sol
+++ b/projects/vaults/contracts/mellow-handler/MellowHandler.sol
@@ -87,17 +87,17 @@ contract MellowHandler is InceptionAssetsHandler, IMellowHandler {
         return;
     }
 
-    /// @dev performs creating a withdrawal request from Mellow Protocol
-    /// @dev requires a specific amount to withdraw
-    function undelegateForceFrom(
-        address mellowVault,
-        uint256 deadline
-    ) external whenNotPaused nonReentrant onlyOperator {
-        if (mellowVault == address(0)) revert InvalidAddress();
-        uint256 amount = mellowRestaker.withdrawEmergencyMellow(mellowVault, deadline);
-        emit StartEmergencyMellowWithdrawal(address(mellowRestaker), amount);
-        return;
-    }
+    // /// @dev performs creating a withdrawal request from Mellow Protocol
+    // /// @dev requires a specific amount to withdraw
+    // function undelegateForceFrom(
+    //     address mellowVault,
+    //     uint256 deadline
+    // ) external whenNotPaused nonReentrant onlyOperator {
+    //     if (mellowVault == address(0)) revert InvalidAddress();
+    //     uint256 amount = mellowRestaker.withdrawEmergencyMellow(mellowVault, deadline);
+    //     emit StartEmergencyMellowWithdrawal(address(mellowRestaker), amount);
+    //     return;
+    // }
 
     /// @dev claims completed withdrawals from Mellow Protocol, if they exist
     function claimCompletedWithdrawals() public whenNotPaused nonReentrant {

--- a/projects/vaults/contracts/restakers/IMellowRestaker.sol
+++ b/projects/vaults/contracts/restakers/IMellowRestaker.sol
@@ -178,31 +178,31 @@ contract IMellowRestaker is
         return expectedAmounts[0];
     }
 
-    function withdrawEmergencyMellow(
-        address _mellowVault,
-        uint256 _deadline
-    ) external override onlyTrustee whenNotPaused returns (uint256) {
-        IMellowVault mellowVault = IMellowVault(_mellowVault);
-        address[] memory tokens;
-        uint256[] memory baseTvlAmounts;
-        (tokens, baseTvlAmounts) = mellowVault.baseTvl();
-        uint256 totalSupply = IERC20(_mellowVault).totalSupply();
+    // function withdrawEmergencyMellow(
+    //     address _mellowVault,
+    //     uint256 _deadline
+    // ) external override onlyTrustee whenNotPaused returns (uint256) {
+    //     IMellowVault mellowVault = IMellowVault(_mellowVault);
+    //     address[] memory tokens;
+    //     uint256[] memory baseTvlAmounts;
+    //     (tokens, baseTvlAmounts) = mellowVault.baseTvl();
+    //     uint256 totalSupply = IERC20(_mellowVault).totalSupply();
 
-        uint256[] memory minAmounts = new uint256[](baseTvlAmounts.length);
-        for (uint256 i = 0; i < baseTvlAmounts.length; i++) {
-            minAmounts[i] = (baseTvlAmounts[i] * pendingMellowRequest(IMellowVault(_mellowVault)).lpAmount / totalSupply) - 1 gwei;
-        }
+    //     uint256[] memory minAmounts = new uint256[](baseTvlAmounts.length);
+    //     for (uint256 i = 0; i < baseTvlAmounts.length; i++) {
+    //         minAmounts[i] = (baseTvlAmounts[i] * pendingMellowRequest(IMellowVault(_mellowVault)).lpAmount / totalSupply) - 1 gwei;
+    //     }
 
-        if (address(mellowDepositWrappers[_mellowVault]) == address(0)) revert InvalidVault();
+    //     if (address(mellowDepositWrappers[_mellowVault]) == address(0)) revert InvalidVault();
 
-        uint256[] memory actualAmounts = mellowVault.emergencyWithdraw(minAmounts, block.timestamp + _deadline);
+    //     uint256[] memory actualAmounts = mellowVault.emergencyWithdraw(minAmounts, block.timestamp + _deadline);
 
-        if (actualAmounts[1] > 0) {
-            IDefaultCollateral(tokens[1]).withdraw(address(this), IERC20(tokens[1]).balanceOf(address(this))); 
-        }
+    //     if (actualAmounts[1] > 0) {
+    //         IDefaultCollateral(tokens[1]).withdraw(address(this), IERC20(tokens[1]).balanceOf(address(this))); 
+    //     }
 
-        return _asset.balanceOf(address(this));
-    }
+    //     return _asset.balanceOf(address(this));
+    // }
 
     function claimableAmount() external view returns (uint256) {
         return _asset.balanceOf(address(this));

--- a/projects/vaults/contracts/vaults/Symbiotic/InceptionVault_S.sol
+++ b/projects/vaults/contracts/vaults/Symbiotic/InceptionVault_S.sol
@@ -21,7 +21,7 @@ contract InceptionVault_S is MellowHandler, IInceptionVault_S {
     IInceptionToken public inceptionToken;
 
     /// @dev Reduces rounding issues
-    uint256 public minAmount;
+    uint256 public withdrawMinAmount;
 
     mapping(address => Withdrawal) private _claimerWithdrawals;
 
@@ -49,6 +49,10 @@ contract InceptionVault_S is MellowHandler, IInceptionVault_S {
     uint64 public optimalWithdrawalRate;
     uint64 public withdrawUtilizationKink;
 
+    /// @dev flash and deposit minAmounts
+    uint256 public flashMinAmount;
+    uint256 public depositMinAmount;
+
     function __InceptionVault_init(
         string memory vaultName,
         address operatorAddress,
@@ -63,7 +67,9 @@ contract InceptionVault_S is MellowHandler, IInceptionVault_S {
         _operator = operatorAddress;
         inceptionToken = _inceptionToken;
 
-        minAmount = 1e16;
+        withdrawMinAmount = 1e16;
+        depositMinAmount = 1e16;
+        flashMinAmount = 1e16;
 
         protocolFee = 50 * 1e8;
 
@@ -86,7 +92,7 @@ contract InceptionVault_S is MellowHandler, IInceptionVault_S {
 
     function __beforeDeposit(address receiver, uint256 amount) internal view {
         if (receiver == address(0)) revert NullParams();
-        if (amount < minAmount) revert LowerMinAmount(minAmount);
+        if (amount < depositMinAmount) revert LowerMinAmount(depositMinAmount);
 
         if (targetCapacity == 0) revert InceptionOnPause();
     }
@@ -216,7 +222,7 @@ contract InceptionVault_S is MellowHandler, IInceptionVault_S {
         __beforeWithdraw(receiver, iShares);
         address claimer = msg.sender;
         uint256 amount = convertToAssets(iShares);
-        if (amount < minAmount) revert LowerMinAmount(minAmount);
+        if (amount < withdrawMinAmount) revert LowerMinAmount(withdrawMinAmount);
 
         // burn Inception token in view of the current ratio
         inceptionToken.burn(claimer, iShares);
@@ -317,7 +323,7 @@ contract InceptionVault_S is MellowHandler, IInceptionVault_S {
     ) private returns (uint256, uint256) {
         uint256 amount = convertToAssets(iShares);
 
-        if (amount < minAmount) revert LowerMinAmount(minAmount);
+        if (amount < flashMinAmount) revert LowerMinAmount(flashMinAmount);
 
         // burn Inception token in view of the current ratio
         inceptionToken.burn(owner, iShares);
@@ -565,9 +571,19 @@ contract InceptionVault_S is MellowHandler, IInceptionVault_S {
         _operator = newOperator;
     }
 
-    function setMinAmount(uint256 newMinAmount) external onlyOwner {
-        emit MinAmountChanged(minAmount, newMinAmount);
-        minAmount = newMinAmount;
+    function setWithdrawMinAmount(uint256 newMinAmount) external onlyOwner {
+        emit WithdrawMinAmountChanged(withdrawMinAmount, newMinAmount);
+        withdrawMinAmount = newMinAmount;
+    }
+
+    function setDepositMinAmount(uint256 newMinAmount) external onlyOwner {
+        emit DepositMinAmountChanged(depositMinAmount, newMinAmount);
+        depositMinAmount = newMinAmount;
+    }
+
+    function setFlashMinAmont(uint256 newMinAmount) external onlyOwner {
+        emit FlashMinAmountChanged(flashMinAmount, newMinAmount);
+        flashMinAmount = newMinAmount;
     }
 
     function setName(string memory newVaultName) external onlyOwner {


### PR DESCRIPTION
**SymbioticVault changes:** 

1. Emergency withdrawal _temporarily_ deprecated.
2. Distinct minimum amounts added for `deposit`, `withdraw`, and `flashWithdraw`.